### PR TITLE
start type checking as early as possible

### DIFF
--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -27,38 +27,56 @@ export default class TsCheckerWebpackPlugin {
       callback();
     });
 
-    // compilation almost finished, start type checking
-    this.compiler.plugin("after-compile", (compilation, callback) => {
+    this.compiler.plugin("compilation", compilation => {
       // Don't run on child compilations
       if (compilation.compiler.isChild()) {
-        callback();
         return;
       }
 
-      const buildFiles = compilation.modules
-        .filter((module: any) => module.built && module.request)
-        .map((module: any) => stripLoader(module.request));
+      this.current = null;
 
-      this.checker.updateBuiltFiles(buildFiles);
+      // compilation for modules almost finished, start type checking
+      compilation.plugin("seal", () => {
+        const buildFiles = compilation.modules
+          .filter((module: any) => module.built && module.request)
+          .map((module: any) => stripLoader(module.request));
 
-      // skip type checking when there are any build errors
-      if (compilation.errors.length > 0) {
-        callback();
-        return;
-      }
+        this.checker.updateBuiltFiles(buildFiles);
 
-      // start type checking
-      this.triggerStart();
-      this.current = this.checker.check();
-      this.registerBlockingCheckHook(this.current, compilation, callback);
+        // skip type checking when there are build errors
+        if (compilation.errors.length > 0) {
+          return;
+        }
+
+        // start type checking
+        this.current = this.checker.check();
+      });
     });
 
-    // let webpack watch type definition files which are not part of the dependency graph
-    // to rebuild on changes automatically
-    compiler.plugin("emit", (compilation, callback) => {
-      const filesToWatch = this.checker.getTypeCheckRelatedFiles();
-      Array.prototype.push.apply(compilation.fileDependencies, filesToWatch);
-      callback();
+    this.compiler.plugin("emit", (compilation, callback) => {
+      // Don't run on child compilations
+      if (compilation.compiler.isChild() || this.current == null) {
+        callback();
+        return;
+      }
+
+      // block emit until type checking is ready
+      this.current
+        .then((result: TsCheckerResult) => {
+          // let webpack watch type definition files which are not part of webpack's dependency graph
+          // to rebuild on changes automatically
+          const filesToWatch = this.checker.getTypeCheckRelatedFiles();
+          Array.prototype.push.apply(compilation.fileDependencies, filesToWatch);
+
+          // pass errors/warnings to webpack
+          const { errors, warnings } = TsCheckerWebpackPlugin.transformToWebpackBuildResult(result);
+          errors.forEach(error => compilation.errors.push(error));
+          warnings.forEach(error => compilation.warnings.push(error));
+          callback();
+        })
+        .catch(e => {
+          callback(e);
+        });
     });
 
     // compilation completely done, kill type checker in build mode
@@ -82,24 +100,7 @@ export default class TsCheckerWebpackPlugin {
     });
   }
 
-  private registerBlockingCheckHook(current: Promise<TsCheckerResult>, compilation: any, callback: Function) {
-    current
-      .then((result: TsCheckerResult) => {
-        const { errors, warnings } = TsCheckerWebpackPlugin.transformToWebpackBuildResult(result);
-        errors.forEach(error => compilation.errors.push(error));
-        warnings.forEach(error => compilation.warnings.push(error));
-        this.triggerDone(errors, warnings);
-        callback();
-      })
-      .catch(e => {
-        this.triggerDone([e]);
-        callback(e);
-      });
-  }
-
   private static transformToWebpackBuildResult(result: TsCheckerResult) {
-    console.log("time", result.time + "ms");
-
     // todo maybe prefer diagnostic error for files with type & lint error
     const allErrors: Array<BaseError> = ([] as Array<BaseError>).concat(result.lints, result.diagnostics);
     const errors: Array<Error> = allErrors.filter(e => !e.isWarningSeverity());
@@ -109,17 +110,5 @@ export default class TsCheckerWebpackPlugin {
       errors,
       warnings,
     };
-  }
-
-  private triggerStart() {
-    this.compiler.applyPlugins("ts-checker-webpack-plugin-start");
-  }
-
-  private triggerDone(errors: Array<Error>, warnings: Array<Error> = []) {
-    const stats = {
-      errors,
-      warnings,
-    };
-    this.compiler.applyPlugins("ts-checker-webpack-plugin-done", stats);
   }
 }


### PR DESCRIPTION
Implements #1 and removes also the plugin hooks which became obsolete due this plugin blocks the compilation always.