### PR TITLE
run plugin on a separate process

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = {
     new TsCheckerWebpackPlugin({
       tsconfig: path.resolve("tsconfig.json"),
       tslint: path.resolve("tslint.json"), // optional
-      memoryLimit: 512, // optional, memory usage in MB
+      memoryLimit: 512, // optional, maximum memory usage in MB
     })
   ]
 };

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module.exports = {
     new TsCheckerWebpackPlugin({
       tsconfig: path.resolve("tsconfig.json"),
       tslint: path.resolve("tslint.json"), // optional
+      memoryLimit: 512, // optional, memory usage in MB
     })
   ]
 };

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm run test -- --coverage --no-cache --runInBand
+  - node --max-old-space-size=250 node_modules/jest/bin/jest.js --coverage --no-cache --runInBand
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
+    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.ts",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
       "ts",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "jest": "^20.0.4",
     "lint-staged": "^3.6.1",
     "null-loader": "^0.1.1",
-    "p-defer": "^1.0.0",
     "prettier": "^1.4.4",
     "react": "^15.6.1",
     "rimraf": "^2.6.1",
@@ -100,6 +99,7 @@
   },
   "dependencies": {
     "es6-error": "^4.0.2",
-    "normalize-path": "^2.1.1"
+    "normalize-path": "^2.1.1",
+    "p-defer": "^1.0.0"
   }
 }

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -6,11 +6,13 @@ import pDefer = require("p-defer");
 
 export default class TsChecker {
   private process: ChildProcess | null = null;
+  private memoryLimit: number;
   private tsconfigPath: string;
   private tslintPath?: string;
   private exitListener: () => void;
 
-  constructor(tsconfigPath: string, tslintPath?: string) {
+  constructor(memoryLimit: number, tsconfigPath: string, tslintPath?: string) {
+    this.memoryLimit = memoryLimit;
     this.tsconfigPath = tsconfigPath;
     this.tslintPath = tslintPath;
     this.exitListener = () => {
@@ -36,7 +38,7 @@ export default class TsChecker {
         process.env.NODE_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
         {
           cwd: process.cwd(),
-          execArgv: [],
+          execArgv: [`--max-old-space-size=${this.memoryLimit}`],
           env: {
             TSCONFIG: this.tsconfigPath,
             ...this.tslintPath ? { TSLINT: this.tslintPath } : {},

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -27,11 +27,12 @@ export default class TsChecker {
     if (this.process == null) {
       // terminate children when main process is gogin to die
       process.on("SIGINT", this.exitListener);
+      process.on("SIGTERM", this.exitListener);
 
       // start child process
       this.process = fork(
         process.env.NODE_ENV === "test"
-          ? path.join(process.cwd(), "node_modules/.bin/_ts-node")
+          ? path.join(process.cwd(), "node_modules/ts-node/dist/_bin.js")
           : require.resolve("./TsCheckerService"),
         process.env.NODE_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
         {

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -36,7 +36,7 @@ export default class TsChecker {
         process.env.NODE_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
         {
           cwd: process.cwd(),
-          execArgv: ["--max-old-space-size=2048"],
+          execArgv: [],
           env: {
             TSCONFIG: this.tsconfigPath,
             ...this.tslintPath ? { TSLINT: this.tslintPath } : {},

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -15,7 +15,7 @@ export default class TsChecker {
     this.tslintPath = tslintPath;
     this.exitListener = () => {
       if (this.process != null) {
-        this.process.kill("SIGINT");
+        this.process.kill();
       }
     };
   }
@@ -26,8 +26,7 @@ export default class TsChecker {
   start() {
     if (this.process == null) {
       // terminate children when main process is gogin to die
-      process.on("SIGINT", this.exitListener);
-      process.on("SIGTERM", this.exitListener);
+      process.on("exit", this.exitListener);
 
       // start child process
       this.process = fork(
@@ -57,7 +56,7 @@ export default class TsChecker {
    */
   kill() {
     if (this.process != null) {
-      process.removeListener("SIGINT", this.exitListener);
+      process.removeListener("exit", this.exitListener);
       this.process.removeAllListeners();
       this.process.kill();
       this.process = null;

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -27,7 +27,7 @@ export default class TsChecker {
    */
   start() {
     if (this.process == null) {
-      // terminate children when main process is gogin to die
+      // terminate children when main process is going to die
       process.on("exit", this.exitListener);
 
       // start child process

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -32,9 +32,7 @@ export default class TsChecker {
 
       // start child process
       this.process = fork(
-        process.env.NODE_ENV === "test"
-          ? path.join(process.cwd(), "node_modules/ts-node/dist/_bin.js")
-          : require.resolve("./TsCheckerService"),
+        process.env.NODE_ENV === "test" ? require.resolve("ts-node/dist/_bin") : require.resolve("./TsCheckerService"),
         process.env.NODE_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
         {
           cwd: process.cwd(),

--- a/src/TsChecker.ts
+++ b/src/TsChecker.ts
@@ -1,4 +1,3 @@
-import * as path from "path";
 import { fork, ChildProcess } from "child_process";
 import { DiagnosticError, LintError } from "./util/Error";
 import { TsCheckerResult } from "./util/IncrementalChecker";
@@ -32,8 +31,10 @@ export default class TsChecker {
 
       // start child process
       this.process = fork(
-        process.env.NODE_ENV === "test" ? require.resolve("ts-node/dist/_bin") : require.resolve("./TsCheckerService"),
-        process.env.NODE_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
+        process.env.TS_CHECKER_ENV === "test"
+          ? require.resolve("ts-node/dist/_bin")
+          : require.resolve("./TsCheckerService"),
+        process.env.TS_CHECKER_ENV === "test" ? [require.resolve("./TsCheckerService")] : [],
         {
           cwd: process.cwd(),
           execArgv: [`--max-old-space-size=${this.memoryLimit}`],

--- a/src/TsCheckerService.ts
+++ b/src/TsCheckerService.ts
@@ -1,0 +1,51 @@
+import IncrementalChecker from "./util/IncrementalChecker";
+
+process.on("SIGINT", function() {
+  process.exit(130);
+});
+
+const tsconfigPath = process.env.TSCONFIG;
+const tslintPath = process.env.TSLINT;
+
+const incrementalChecker = new IncrementalChecker(tsconfigPath, tslintPath);
+
+const messageOk = {
+  id: "ok",
+};
+
+const sendMessage = (...args: Array<any>) => {
+  (process as any).send(...args);
+};
+
+process.on("message", function(message: any) {
+  switch (message.id) {
+    case "invalidateFiles": {
+      incrementalChecker.invalidateFiles(message.changes, message.removals);
+      sendMessage(messageOk);
+      break;
+    }
+    case "typeCheckRelatedFiles": {
+      const files = incrementalChecker.getTypeCheckRelatedFiles();
+      sendMessage({
+        ...messageOk,
+        files,
+      });
+      break;
+    }
+    case "typeCheck": {
+      incrementalChecker.updateBuiltFiles(message.files);
+      const result = incrementalChecker.run();
+
+      const lints = result.lints.map(lint => lint.toJSON());
+      const diagnostics = result.diagnostics.map(diagnostic => diagnostic.toJSON());
+
+      sendMessage({
+        ...messageOk,
+        ...result,
+        lints,
+        diagnostics,
+      });
+      break;
+    }
+  }
+});

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -68,6 +68,7 @@ export default class TsCheckerWebpackPlugin {
 
         // skip type checking when there are build errors
         if (compilation.errors.length > 0) {
+          this.current = null;
           return;
         }
 

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -51,6 +51,11 @@ export default class TsCheckerWebpackPlugin {
     });
 
     this.compiler.plugin("compilation", compilation => {
+      // Don't run on child compilations
+      if (compilation.compiler.isChild()) {
+        return;
+      }
+
       this.current = null;
 
       // compilation for modules almost finished, start type checking

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -7,6 +7,7 @@ import { stripLoader } from "./util/webpackModule";
 export interface TsCheckerWebpackPluginOptions {
   tsconfig: string;
   tslint?: string;
+  memoryLimit?: number;
 }
 
 export default class TsCheckerWebpackPlugin {
@@ -17,7 +18,8 @@ export default class TsCheckerWebpackPlugin {
   private builtFiles: Array<string> = [];
 
   constructor(options: TsCheckerWebpackPluginOptions) {
-    this.checker = new TsChecker(options.tsconfig, options.tslint);
+    const { tsconfig, tslint, memoryLimit = 512 } = options;
+    this.checker = new TsChecker(memoryLimit, tsconfig, tslint);
     this.checker.start();
   }
 

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -1,5 +1,6 @@
 import { Compiler } from "webpack";
-import TsChecker, { TsCheckerResult } from "./TsChecker";
+import TsChecker from "./TsChecker";
+import { TsCheckerResult } from "./util/IncrementalChecker";
 import { BaseError } from "./util/Error";
 import { stripLoader } from "./util/webpackModule";
 
@@ -12,19 +13,29 @@ export default class TsCheckerWebpackPlugin {
   private watchMode: boolean = false;
   private compiler: Compiler;
   private checker: TsChecker;
-  private current?: Promise<TsCheckerResult> | null = null;
+  private current: Promise<TsCheckerResult | void> | null = null;
+  private builtFiles: Array<string> = [];
 
   constructor(options: TsCheckerWebpackPluginOptions) {
     this.checker = new TsChecker(options.tsconfig, options.tslint);
+    this.checker.start();
   }
 
   apply(compiler: Compiler) {
     this.compiler = compiler;
 
-    // detect watch mode
+    // detect watch mode & wait until all changed files are invalidated
     this.compiler.plugin("watch-run", (watching, callback) => {
       this.watchMode = true;
-      callback();
+      // wait for next tick to make sure that the synchronous "aggregated" event was called before
+      process.nextTick(() => {
+        if (this.current !== null) {
+          this.current.then(() => callback()).catch(callback);
+          this.current = null;
+        } else {
+          callback();
+        }
+      });
     });
 
     this.compiler.plugin("compilation", compilation => {
@@ -41,7 +52,7 @@ export default class TsCheckerWebpackPlugin {
           .filter((module: any) => module.built && module.request)
           .map((module: any) => stripLoader(module.request));
 
-        this.checker.updateBuiltFiles(buildFiles);
+        Array.prototype.push.apply(this.builtFiles, buildFiles);
 
         // skip type checking when there are build errors
         if (compilation.errors.length > 0) {
@@ -49,11 +60,11 @@ export default class TsCheckerWebpackPlugin {
         }
 
         // start type checking
-        this.current = this.checker.check();
+        this.current = this.checker.check(this.builtFiles);
       });
     });
 
-    this.compiler.plugin("emit", (compilation, callback) => {
+    this.compiler.plugin("after-emit", (compilation, callback) => {
       // Don't run on child compilations
       if (compilation.compiler.isChild() || this.current == null) {
         callback();
@@ -61,27 +72,33 @@ export default class TsCheckerWebpackPlugin {
       }
 
       // block emit until type checking is ready
-      this.current
-        .then((result: TsCheckerResult) => {
-          // let webpack watch type definition files which are not part of webpack's dependency graph
-          // to rebuild on changes automatically
-          const filesToWatch = this.checker.getTypeCheckRelatedFiles();
-          Array.prototype.push.apply(compilation.fileDependencies, filesToWatch);
-
+      (this.current as Promise<TsCheckerResult>)
+        .then((result: any) => {
+          // reset built files
+          this.builtFiles.length = 0;
           // pass errors/warnings to webpack
           const { errors, warnings } = TsCheckerWebpackPlugin.transformToWebpackBuildResult(result);
           errors.forEach(error => compilation.errors.push(error));
           warnings.forEach(error => compilation.warnings.push(error));
-          callback();
         })
-        .catch(e => {
-          callback(e);
-        });
+        .then(() => this.checker.getTypeCheckRelatedFiles())
+        .then(filesToWatch => {
+          // let webpack watch type definition files which are not part of the dependency graph
+          // to rebuild on changes automatically
+          Array.prototype.push.apply(compilation.fileDependencies, filesToWatch);
+        })
+        .then(callback)
+        .catch(callback);
+
+      // reset promise
+      this.current = null;
     });
 
     // compilation completely done, kill type checker in build mode
     this.compiler.plugin("done", () => {
-      if (this.watchMode) {
+      if (!this.watchMode) {
+        this.checker.kill();
+      } else {
         // wait for next tick until the watcher is ready
         process.nextTick(() => {
           // register change listener to watcher
@@ -92,7 +109,7 @@ export default class TsCheckerWebpackPlugin {
             // register change listener to get changed & removed files
             watcher.once("aggregated", (changes: Array<string>, removals: Array<string>) => {
               // update file cache
-              this.checker.invalidateFiles(changes, removals);
+              this.current = this.checker.invalidateFiles(changes, removals);
             });
           }
         });

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -41,11 +41,6 @@ export default class TsCheckerWebpackPlugin {
     });
 
     this.compiler.plugin("compilation", compilation => {
-      // Don't run on child compilations
-      if (compilation.compiler.isChild()) {
-        return;
-      }
-
       this.current = null;
 
       // compilation for modules almost finished, start type checking
@@ -120,9 +115,7 @@ export default class TsCheckerWebpackPlugin {
 
     // kill checker when webpack watch compiler was closed
     this.compiler.plugin("watch-close", () => {
-      if (this.watchMode) {
-        this.checker.kill();
-      }
+      this.checker.kill();
     });
   }
 

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -26,9 +26,19 @@ export default class TsCheckerWebpackPlugin {
   apply(compiler: Compiler) {
     this.compiler = compiler;
 
-    // detect watch mode & wait until all changed files are invalidated
+    // detect watch mode
     this.compiler.plugin("watch-run", (watching, callback) => {
       this.watchMode = true;
+      callback();
+    });
+
+    // wait until all changed files are invalidated
+    this.compiler.plugin("make", (compilation, callback) => {
+      // Don't run on child compilations & skip for build mode
+      if (compilation.compiler.isChild() || !this.watchMode) {
+        callback();
+        return;
+      }
       // wait for next tick to make sure that the synchronous "aggregated" event was called before
       process.nextTick(() => {
         if (this.current !== null) {

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -115,6 +115,13 @@ export default class TsCheckerWebpackPlugin {
         });
       }
     });
+
+    // kill checker when webpack watch compiler was closed
+    this.compiler.plugin("watch-close", () => {
+      if (this.watchMode) {
+        this.checker.kill();
+      }
+    });
   }
 
   private static transformToWebpackBuildResult(result: TsCheckerResult) {

--- a/src/util/Error.ts
+++ b/src/util/Error.ts
@@ -32,6 +32,22 @@ export class DiagnosticError extends Es6Error implements BaseError {
     return this.severity === "warning";
   }
 
+  toJSON() {
+    return {
+      name: "DiagnosticError",
+      message: this.message,
+      code: this.code,
+      severity: this.severity,
+      file: this.file,
+      line: this.line,
+      character: this.character,
+    };
+  }
+
+  static fromJSON(error: any) {
+    return new DiagnosticError(error.message, error.code, error.severity, error.file, error.line, error.character);
+  }
+
   static createFromDiagnostic(diagnostic: Diagnostic) {
     const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
     return new DiagnosticError(
@@ -65,6 +81,22 @@ export class LintError extends Es6Error implements BaseError {
 
   isWarningSeverity() {
     return this.severity === "warning";
+  }
+
+  toJSON() {
+    return {
+      name: "LintError",
+      message: this.message,
+      rule: this.rule,
+      severity: this.severity,
+      file: this.file,
+      line: this.line,
+      character: this.character,
+    };
+  }
+
+  static fromJSON(error: any) {
+    return new LintError(error.message, error.rule, error.severity, error.file, error.line, error.character);
   }
 
   static createFromLint(lint: RuleFailure) {

--- a/src/util/IncrementalChecker.ts
+++ b/src/util/IncrementalChecker.ts
@@ -69,8 +69,8 @@ export default class IncrementalChecker {
     const lintEnd = Date.now();
 
     return {
-      checkTime: lintEnd - lintStart,
-      lintTime: checkEnd - checkStart,
+      checkTime: checkEnd - checkStart,
+      lintTime: lintEnd - lintStart,
       diagnostics: diagnostics.map(DiagnosticError.createFromDiagnostic),
       lints: lints.map(LintError.createFromLint),
     };

--- a/test/__snapshots__/WatchCases.test.ts.snap
+++ b/test/__snapshots__/WatchCases.test.ts.snap
@@ -90,6 +90,20 @@ Object {
 }
 `;
 
+exports[`WatchCases ignore-child-compiler-no-error 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`WatchCases ignore-child-compiler-no-error 2`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
 exports[`WatchCases ts-dependency-only-error 1`] = `
 Object {
   "errors": Array [],

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,0 +1,1 @@
+process.env.TS_CHECKER_ENV = "test";

--- a/test/watchCases/ignore-child-compiler-no-error/steps/0/entry.ts
+++ b/test/watchCases/ignore-child-compiler-no-error/steps/0/entry.ts
@@ -1,0 +1,1 @@
+const x: number = 5;

--- a/test/watchCases/ignore-child-compiler-no-error/steps/1/entry.ts
+++ b/test/watchCases/ignore-child-compiler-no-error/steps/1/entry.ts
@@ -1,0 +1,1 @@
+const x: number = 6;

--- a/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/watchCases/ignore-child-compiler-no-error/webpack.config.ts
+++ b/test/watchCases/ignore-child-compiler-no-error/webpack.config.ts
@@ -1,0 +1,34 @@
+import * as path from "path";
+import TsCheckerWebpackPlugin from "../../../src/TsCheckerWebpackPlugin";
+import HtmlWebpackPlugin = require("html-webpack-plugin");
+
+module.exports = {
+  context: __dirname,
+  entry: "./src/entry.ts",
+  output: {
+    filename: "bundle.js",
+  },
+  resolve: {
+    // Add `.ts` and `.tsx` as a resolvable extension.
+    extensions: [".ts", ".tsx", ".js"], // note if using webpack 1 you'd also need a '' in the array as well
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new TsCheckerWebpackPlugin({
+      tsconfig: path.join(__dirname, "tsconfig.json"),
+    }),
+    new HtmlWebpackPlugin(),
+  ],
+};


### PR DESCRIPTION
Implements #2 

Type checking & linting runs now on another thread to avoid blocking the webpack thread. We start the checking process right after all modules were built (seal) and get or wait for the results after webpack is done (after-emit). It's the earliest and the latest possible moment to do our stuff.

On my private repo the incremental build time is nearly identical as without type checking and without linting. 

