### PR TITLE
check only modified & affected files

### DIFF
--- a/src/checker/IncrementalChecker.ts
+++ b/src/checker/IncrementalChecker.ts
@@ -65,8 +65,8 @@ export default class IncrementalChecker {
     this.failures.forEach((file: string) => affectedFiles.add(file));
     this.failures.clear();
 
-    console.log("affectedFiles", affectedFiles.values());
-    console.log("fullCheckNecessary", fullCheckNecessary);
+    // console.log("affectedFiles", affectedFiles.values());
+    // console.log("fullCheckNecessary", fullCheckNecessary);
 
     const fullCheckSourceFiles = allSourceFiles.filter(
       (file: SourceFile) => !this.fileCache.isNodeModule(file.fileName)

--- a/src/checker/IncrementalChecker.ts
+++ b/src/checker/IncrementalChecker.ts
@@ -56,9 +56,7 @@ export default class IncrementalChecker {
     const addedFiles = this.fileCache.getAddedFiles();
 
     const modifiedFiles = [...invalidatedFiles, ...addedFiles];
-    const fullCheckNecessary = modifiedFiles.some((fileName: string) =>
-      this.fileCache.isFileGlobalTypeCheckable(fileName)
-    );
+    const fullCheckNecessary = modifiedFiles.some((fileName: string) => this.fileCache.hasFileGlobalImpacts(fileName));
     // todo build affectedFiles only when fullCheckNecessary is false
     // calculate affected files
     const affectedFiles = this.fileCache.getAffectedFiles(modifiedFiles);

--- a/src/checker/IncrementalChecker.ts
+++ b/src/checker/IncrementalChecker.ts
@@ -129,17 +129,6 @@ export default class IncrementalChecker {
     };
   }
 
-  updateBuiltFiles(changes: Array<string>) {
-    changes.forEach(file => {
-      // normalize system path style to unix style
-      const normalizedFile = normalizePath(file);
-      // invalidate file
-      this.fileCache.built(normalizedFile);
-      // remove type definitions for files like css-modules, cause file watcher may detect changes to late
-      this.fileCache.removeTypeDefinitionOfFile(normalizedFile);
-    });
-  }
-
   invalidateFiles(changed: Array<string>, removed: Array<string>) {
     // todo prefill cache for invalidated files to get another performance boost
     changed.forEach(file => {

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -14,6 +14,10 @@ export interface FileState {
    */
   readonly typeDefinition: boolean;
   /**
+   * Determines if this file is a ts file
+   */
+  readonly ts: boolean;
+  /**
    * Source for TS checker
    */
   source: SourceFile | null;
@@ -34,6 +38,7 @@ export interface FileState {
 const createFile = (file: string): FileState => ({
   file,
   typeDefinition: TYPE_DEFINITION.test(file),
+  ts: TS_FILE.test(file),
   source: null,
   dependencies: [],
   globalImpact: false,
@@ -124,10 +129,10 @@ export default class FileCache {
     const files = new Set<string>();
 
     this.getFiles()
-      .filter(fileState => TS_FILE.test(fileState.file))
+      .filter(fileState => fileState.ts)
       .forEach(fileState => {
         files.add(fileState.file);
-        fileState.dependencies.filter(file => TS_FILE.test(file)).forEach(dep => files.add(dep));
+        fileState.dependencies.filter(file => !files.has(file) && TS_FILE.test(file)).forEach(dep => files.add(dep));
       });
 
     return Array.from(files);

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -159,7 +159,7 @@ export default class FileCache {
       .map(fileState => fileState.file);
   }
 
-  getAddedFiles() {
+  getModifiedFiles() {
     return Array.from(this.added.values());
   }
 

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -72,9 +72,8 @@ export default class FileCache {
 
     const state = this.get(file) as FileState;
 
-    if (state.typeDefinition) {
-      state.globalImpact = hasGlobalImpact(source);
-    }
+    // each source file can have a global impact
+    state.globalImpact = hasGlobalImpact(source);
   }
 
   get(file: string) {

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -100,6 +100,7 @@ export default class FileCache {
   }
 
   remove(file: string) {
+    this.added.delete(file);
     this.files.delete(file);
   }
 

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -1,7 +1,6 @@
 import { SourceFile } from "typescript";
 import { getDependencies, hasGlobalImpact } from "./dependencies";
 
-const NODE_MODULE = /node_modules/;
 const TYPE_DEFINITION = /.*\.d\.ts$/;
 
 export interface FileState {
@@ -9,10 +8,6 @@ export interface FileState {
    * File path of file for reverse matching
    */
   readonly file: string;
-  /**
-   * Determines if this file is a node_module
-   */
-  readonly nodeModule: boolean;
   /**
    * Determines if this file is a type definition file
    */
@@ -41,7 +36,6 @@ export interface FileState {
 
 const createFile = (file: string): FileState => ({
   file,
-  nodeModule: NODE_MODULE.test(file),
   typeDefinition: TYPE_DEFINITION.test(file),
   source: null,
   dependencies: [],
@@ -114,14 +108,6 @@ export default class FileCache {
     if (this.exist(typeFile)) {
       this.remove(typeFile);
     }
-  }
-
-  isNodeModule(file: string) {
-    if (this.exist(file)) {
-      const fileState = this.files.get(file) as FileState;
-      return fileState.nodeModule;
-    }
-    return false;
   }
 
   hasFileGlobalImpacts(file: string) {

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -125,7 +125,7 @@ export default class FileCache {
     return false;
   }
 
-  isFileGlobalTypeCheckable(file: string) {
+  hasFileGlobalImpacts(file: string) {
     if (this.exist(file)) {
       const fileState = this.files.get(file) as FileState;
       return fileState.globalImpact;

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -135,7 +135,7 @@ export default class FileCache {
   isFileLintable(file: string) {
     if (this.exist(file)) {
       const fileState = this.files.get(file) as FileState;
-      return !fileState.linted && !fileState.typeDefinition && !fileState.nodeModule;
+      return !fileState.linted && !fileState.typeDefinition;
     }
     return false;
   }

--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -155,7 +155,9 @@ export default class FileCache {
   }
 
   getInvalidatedFiles() {
-    return this.getFiles().filter(fileState => fileState.source == null).map(fileState => fileState.file);
+    return this.getFiles()
+      .filter(fileState => fileState.source == null)
+      .map(fileState => fileState.file);
   }
 
   getAddedFiles() {
@@ -172,8 +174,6 @@ export default class FileCache {
   }
 
   getAffectedFiles(modifiedFiles: Array<string>) {
-    // all dependencies of a file
-    const dependencyTree = new Map<string, Array<string>>();
     // all files that depent on a file
     const reverseDependencyTree = new Map<string, Array<string>>();
     // affected modules map
@@ -183,7 +183,6 @@ export default class FileCache {
 
     // build dependency & reverse dependency tree
     fileStates.forEach((fileState: FileState) => {
-      dependencyTree.set(fileState.file, fileState.dependencies);
       fileState.dependencies.forEach((fileName: string) => {
         if (!reverseDependencyTree.has(fileName)) {
           reverseDependencyTree.set(fileName, []);

--- a/src/util/dependencies.ts
+++ b/src/util/dependencies.ts
@@ -11,7 +11,7 @@ const hasModules = (sourceFile: SourceFile): boolean => {
   return /import |export |module.exports|exports/.test(sourceFile.text);
 };
 
-export const getNodes = (item: { forEachChild: (cbNode: (node: Node) => void) => void }): Array<Node> => {
+const getNodes = (item: { forEachChild: (cbNode: (node: Node) => void) => void }): Array<Node> => {
   const nodes: Array<Node> = [];
   item.forEachChild((node: Node) => {
     nodes.push(node);

--- a/src/util/dependencies.ts
+++ b/src/util/dependencies.ts
@@ -1,0 +1,35 @@
+import { Node, SyntaxKind, SourceFile } from "typescript";
+
+const hasNodeGlobalImpact = (node: Node): boolean => {
+  if (node.kind === SyntaxKind.DeclareKeyword) {
+    return true;
+  }
+  const nodes: Array<Node> = [];
+  node.forEachChild((node: Node) => {
+    nodes.push(node);
+  });
+  return nodes.some(hasNodeGlobalImpact);
+};
+
+export const getNodes = (sourceFile: SourceFile): Array<Node> => {
+  const nodes: Array<Node> = [];
+  sourceFile.forEachChild((node: Node) => {
+    nodes.push(node);
+  });
+  return nodes;
+};
+
+export const hasGlobalImpact = (sourceFile: SourceFile): boolean => {
+  const nodes = getNodes(sourceFile);
+  return nodes.some(hasNodeGlobalImpact);
+};
+
+export const getDependencies = (sourceFile: SourceFile) => {
+  const resolvedModules = (sourceFile as any).resolvedModules;
+  if (resolvedModules) {
+    return Array.from(resolvedModules.values())
+      .filter((resolved: any) => Boolean(resolved))
+      .map((resolved: any) => resolved.resolvedFileName);
+  }
+  return [];
+};

--- a/src/util/dependencies.ts
+++ b/src/util/dependencies.ts
@@ -4,16 +4,16 @@ const hasNodeGlobalImpact = (node: Node): boolean => {
   if (node.kind === SyntaxKind.DeclareKeyword) {
     return true;
   }
-  const nodes: Array<Node> = [];
-  node.forEachChild((node: Node) => {
-    nodes.push(node);
-  });
-  return nodes.some(hasNodeGlobalImpact);
+  return getNodes(node).some(hasNodeGlobalImpact);
 };
 
-export const getNodes = (sourceFile: SourceFile): Array<Node> => {
+const hasModules = (sourceFile: SourceFile): boolean => {
+  return /import |export |module.exports|exports/.test(sourceFile.text);
+};
+
+export const getNodes = (item: { forEachChild: (cbNode: (node: Node) => void) => void }): Array<Node> => {
   const nodes: Array<Node> = [];
-  sourceFile.forEachChild((node: Node) => {
+  item.forEachChild((node: Node) => {
     nodes.push(node);
   });
   return nodes;
@@ -21,7 +21,7 @@ export const getNodes = (sourceFile: SourceFile): Array<Node> => {
 
 export const hasGlobalImpact = (sourceFile: SourceFile): boolean => {
   const nodes = getNodes(sourceFile);
-  return nodes.some(hasNodeGlobalImpact);
+  return nodes.some(hasNodeGlobalImpact) || !hasModules(sourceFile);
 };
 
 export const getDependencies = (sourceFile: SourceFile) => {

--- a/src/util/webpackModule.ts
+++ b/src/util/webpackModule.ts
@@ -1,8 +1,0 @@
-export const stripLoader = (filePath: string) => {
-  const lastIndex = filePath.lastIndexOf("!");
-
-  if (lastIndex !== -1) {
-    return filePath.substr(lastIndex + 1);
-  }
-  return filePath;
-};

--- a/src/worker/TsCheckerRuntime.ts
+++ b/src/worker/TsCheckerRuntime.ts
@@ -67,7 +67,6 @@ process.on("message", function(message: any) {
       break;
     }
     case "typeCheck": {
-      incrementalChecker.updateBuiltFiles(message.files);
       const result = incrementalChecker.run();
 
       if (config.ignoreDiagnostics.length) {

--- a/src/worker/TsCheckerWorker.ts
+++ b/src/worker/TsCheckerWorker.ts
@@ -92,8 +92,8 @@ export default class TsCheckerWorker {
   /**
    * Pass files that were (re-)built by webpack and start type checking and linting
    */
-  check(files: Array<string>): Promise<WebpackBuildResult> {
-    return this.sendAndWait("typeCheck", { files }).then(deserializeWebpackBuildResult);
+  check(): Promise<WebpackBuildResult> {
+    return this.sendAndWait("typeCheck").then(deserializeWebpackBuildResult);
   }
 
   /**

--- a/test/TypescriptFileCases.test.ts
+++ b/test/TypescriptFileCases.test.ts
@@ -1,0 +1,31 @@
+import * as path from "path";
+import * as fs from "fs-extra";
+import * as ts from "typescript";
+
+import { satisfiesVersionRequirements } from "./_util/testHelper";
+
+const testCasesPath = path.join(__dirname, "typescriptFileCases");
+const tests = fs.readdirSync(testCasesPath).filter(dir => fs.statSync(path.join(testCasesPath, dir)).isDirectory());
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+
+describe("TypescriptFileCases", () => {
+  tests.forEach(testName => {
+    const testPath = path.join(testCasesPath, testName);
+    const skipTest = !satisfiesVersionRequirements(path.join(testPath, "versions.json"));
+    const testHelper = require(path.join(testPath, "test.ts"));
+    const tsconfigPath = path.join(testPath, "tsconfig.json");
+
+    (skipTest ? it.skip : it)(testName, () => {
+      const programConfig = ts.parseJsonConfigFileContent(
+        ts.readConfigFile(tsconfigPath, ts.sys.readFile).config,
+        ts.sys,
+        path.dirname(tsconfigPath)
+      );
+      const programm = ts.createProgram(programConfig.fileNames, programConfig.options);
+      const sourceFiles = programm.getSourceFiles();
+
+      testHelper.expectSourceFiles(sourceFiles);
+    });
+  });
+});

--- a/test/typescriptFileCases/dependencies/src/entry.ts
+++ b/test/typescriptFileCases/dependencies/src/entry.ts
@@ -1,0 +1,17 @@
+// lib
+import * as React from "react";
+
+// include
+import "./modules/polyfill";
+
+// normal import
+import { module1 } from "./modules/module1";
+
+// interface import
+import { Interface1 } from "./modules/interface";
+
+// import with require
+import module2 = require("./modules/module2");
+
+// commonjs require
+const module3 = require("./modules/module3").module3;

--- a/test/typescriptFileCases/dependencies/src/modules/interface.ts
+++ b/test/typescriptFileCases/dependencies/src/modules/interface.ts
@@ -1,0 +1,1 @@
+export interface Interface1 {}

--- a/test/typescriptFileCases/dependencies/src/modules/module1.ts
+++ b/test/typescriptFileCases/dependencies/src/modules/module1.ts
@@ -1,0 +1,1 @@
+export function module1() {}

--- a/test/typescriptFileCases/dependencies/src/modules/module2.ts
+++ b/test/typescriptFileCases/dependencies/src/modules/module2.ts
@@ -1,0 +1,1 @@
+export function module2() {}

--- a/test/typescriptFileCases/dependencies/src/modules/module3.ts
+++ b/test/typescriptFileCases/dependencies/src/modules/module3.ts
@@ -1,0 +1,1 @@
+export function module3() {}

--- a/test/typescriptFileCases/dependencies/test.ts
+++ b/test/typescriptFileCases/dependencies/test.ts
@@ -1,0 +1,25 @@
+import { SourceFile } from "typescript";
+import normalizePath = require("normalize-path");
+import * as path from "path";
+import { getDependencies } from "../../../src/util/dependencies";
+
+export function expectSourceFiles(sourceFiles: Array<SourceFile>) {
+  const entry = path.join(__dirname, "./src/entry.ts");
+
+  const dependencies = [
+    path.join(__dirname, "./src/modules/interface.ts"),
+    path.join(__dirname, "./src/modules/module1.ts"),
+    path.join(__dirname, "./src/modules/module2.ts"),
+  ].map(normalizePath);
+
+  const requireDependencies = [path.join(__dirname, "./src/modules/module3.ts")].map(normalizePath);
+
+  const entrySource = sourceFiles.find(file => file.fileName === entry);
+
+  const entryDependencies = getDependencies(entrySource);
+
+  dependencies.forEach(dep => expect(entryDependencies).toContain(dep));
+
+  // commonjs require calls are not detected
+  requireDependencies.forEach(dep => expect(entryDependencies).not.toContain(dep));
+}

--- a/test/typescriptFileCases/dependencies/test.ts
+++ b/test/typescriptFileCases/dependencies/test.ts
@@ -1,6 +1,6 @@
+import * as path from "path";
 import { SourceFile } from "typescript";
 import normalizePath = require("normalize-path");
-import * as path from "path";
 import { getDependencies } from "../../../src/util/dependencies";
 
 export function expectSourceFiles(sourceFiles: Array<SourceFile>) {

--- a/test/typescriptFileCases/dependencies/test.ts
+++ b/test/typescriptFileCases/dependencies/test.ts
@@ -4,7 +4,7 @@ import normalizePath = require("normalize-path");
 import { getDependencies } from "../../../src/util/dependencies";
 
 export function expectSourceFiles(sourceFiles: Array<SourceFile>) {
-  const entry = path.join(__dirname, "./src/entry.ts");
+  const entry = normalizePath(path.join(__dirname, "./src/entry.ts"));
 
   const dependencies = [
     path.join(__dirname, "./src/modules/interface.ts"),
@@ -14,7 +14,7 @@ export function expectSourceFiles(sourceFiles: Array<SourceFile>) {
 
   const requireDependencies = [path.join(__dirname, "./src/modules/module3.ts")].map(normalizePath);
 
-  const entrySource = sourceFiles.find(file => normalizePath(file.fileName) === entry);
+  const entrySource = sourceFiles.find(file => file.fileName === entry);
 
   const entryDependencies = getDependencies(entrySource);
 

--- a/test/typescriptFileCases/dependencies/test.ts
+++ b/test/typescriptFileCases/dependencies/test.ts
@@ -14,7 +14,7 @@ export function expectSourceFiles(sourceFiles: Array<SourceFile>) {
 
   const requireDependencies = [path.join(__dirname, "./src/modules/module3.ts")].map(normalizePath);
 
-  const entrySource = sourceFiles.find(file => file.fileName === entry);
+  const entrySource = sourceFiles.find(file => normalizePath(file.fileName) === entry);
 
   const entryDependencies = getDependencies(entrySource);
 

--- a/test/typescriptFileCases/dependencies/tsconfig.json
+++ b/test/typescriptFileCases/dependencies/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/typescriptFileCases/global-impact/src/with-global-impact/assets.d.ts
+++ b/test/typescriptFileCases/global-impact/src/with-global-impact/assets.d.ts
@@ -1,0 +1,24 @@
+declare module "*.bmp" {
+  const content: string;
+  export = content;
+}
+
+declare module "*.gif" {
+  const content: string;
+  export = content;
+}
+
+declare module "*.jpg" {
+  const content: string;
+  export = content;
+}
+
+declare module "*.jpeg" {
+  const content: string;
+  export = content;
+}
+
+declare module "*.svg" {
+  const content: string;
+  export = content;
+}

--- a/test/typescriptFileCases/global-impact/src/with-global-impact/empty.ts
+++ b/test/typescriptFileCases/global-impact/src/with-global-impact/empty.ts
@@ -1,0 +1,1 @@
+// empty files are considered to be global

--- a/test/typescriptFileCases/global-impact/src/with-global-impact/global-export.ts
+++ b/test/typescriptFileCases/global-impact/src/with-global-impact/global-export.ts
@@ -1,0 +1,1 @@
+export declare class Action {}

--- a/test/typescriptFileCases/global-impact/src/with-global-impact/without-modules.ts
+++ b/test/typescriptFileCases/global-impact/src/with-global-impact/without-modules.ts
@@ -1,0 +1,2 @@
+// files without modules/commonjs are also global
+function test() {}

--- a/test/typescriptFileCases/global-impact/src/without-global-impact/awesome.d.ts
+++ b/test/typescriptFileCases/global-impact/src/without-global-impact/awesome.d.ts
@@ -1,0 +1,1 @@
+export function awesomeExternal(x: string): string;

--- a/test/typescriptFileCases/global-impact/src/without-global-impact/export.ts
+++ b/test/typescriptFileCases/global-impact/src/without-global-impact/export.ts
@@ -1,0 +1,1 @@
+export class Action {}

--- a/test/typescriptFileCases/global-impact/src/without-global-impact/import-named.ts
+++ b/test/typescriptFileCases/global-impact/src/without-global-impact/import-named.ts
@@ -1,0 +1,1 @@
+import { test } from "./test";

--- a/test/typescriptFileCases/global-impact/src/without-global-impact/import.ts
+++ b/test/typescriptFileCases/global-impact/src/without-global-impact/import.ts
@@ -1,0 +1,1 @@
+import "./test";

--- a/test/typescriptFileCases/global-impact/src/without-global-impact/module-export.ts
+++ b/test/typescriptFileCases/global-impact/src/without-global-impact/module-export.ts
@@ -1,0 +1,1 @@
+module.exports = class Action {};

--- a/test/typescriptFileCases/global-impact/test.ts
+++ b/test/typescriptFileCases/global-impact/test.ts
@@ -1,0 +1,31 @@
+import * as path from "path";
+import * as fs from "fs";
+import { SourceFile } from "typescript";
+import normalizePath = require("normalize-path");
+import { hasGlobalImpact } from "../../../src/util/dependencies";
+
+const getFiles = folder =>
+  fs
+    .readdirSync(folder)
+    .map(file => path.join(folder, file))
+    .filter(file => fs.statSync(file).isFile())
+    .map(normalizePath);
+
+const getSourceFiles = (files: Array<string>, sourceFiles: Array<SourceFile>) =>
+  sourceFiles.filter(file => files.indexOf(file.fileName) !== -1);
+
+const testGlobalImpact = (result: boolean, testPath: string, sourceFiles: Array<SourceFile>) => {
+  const testFiles = getFiles(testPath);
+  const testSourceFiles = getSourceFiles(testFiles, sourceFiles);
+
+  expect(testSourceFiles).toHaveLength(testFiles.length);
+
+  testSourceFiles.forEach(file => {
+    expect(file.fileName + ":" + hasGlobalImpact(file)).toBe(file.fileName + ":" + result);
+  });
+};
+
+export function expectSourceFiles(sourceFiles: Array<SourceFile>) {
+  testGlobalImpact(true, path.join(__dirname, "./src/with-global-impact"), sourceFiles);
+  testGlobalImpact(false, path.join(__dirname, "./src/without-global-impact"), sourceFiles);
+}

--- a/test/typescriptFileCases/global-impact/tsconfig.json
+++ b/test/typescriptFileCases/global-impact/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Idea: try to determine which files needs to be checked on a file change
- check all files & it's dependencies that failed before
- check all files that changed & all files that were affected by this change
- run a full type check when a file changed, that has global impact (e.g. a file with type definitions)

Changes:
- remove module built information from webpack (usage was already removed in #43)
- check all files (even node_modules)
- lints only root files (except d.t.s files)
- incremental type checking in watch-mode
