### PR TITLE
tslint emit failures as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ new TsCheckerWebpackPlugin(options: object)
 |:--|:--:|:----------|
 |**`tsconfig`**|`{String}`|Absolute path to tsconfig.json file.|
 |**`tslint`**|`{String}`|Absolute path to tslint.json file. <br>Default: `undefined`|
+|**`tslintEmitErrors`**|`{Boolean}`|Forces tslint to always emit error instead of it's default severity. <br>Default: `false`|
 |**`memoryLimit`**|`{Number}`|Memory limit for the type checker process in MB. <br>Default: `512`|
 |**`diagnosticFormatter`**|`{String}`|Formatter for TypeScript Diagnostics. <br>One of `ts-loader`, `stylish` or `codeframe`.<br> Default: `ts-loader`|
 |**`timings`**|`{Boolean}`|Logs timing information of the type checker. <br>Default: `false`|

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ new TsCheckerWebpackPlugin(options: object)
 |:--|:--:|:----------|
 |**`tsconfig`**|`{String}`|Absolute path to tsconfig.json file.|
 |**`tslint`**|`{String}`|Absolute path to tslint.json file. <br>Default: `undefined`|
-|**`tslintEmitErrors`**|`{Boolean}`|Forces tslint to always emit error instead of it's default severity. <br>Default: `false`|
+|**`tslintEmitErrors`**|`{Boolean}`|Report all TSLint failures as webpack errors regardless of the rule severity. <br>Default: `false`|
 |**`memoryLimit`**|`{Number}`|Memory limit for the type checker process in MB. <br>Default: `512`|
 |**`diagnosticFormatter`**|`{String}`|Formatter for TypeScript Diagnostics. <br>One of `ts-loader`, `stylish` or `codeframe`.<br> Default: `ts-loader`|
 |**`timings`**|`{Boolean}`|Logs timing information of the type checker. <br>Default: `false`|

--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -7,6 +7,7 @@ import { WebpackBuildResult } from "./checker/resultSerializer";
 export interface TsCheckerWebpackPluginOptions {
   tsconfig: string;
   tslint?: string;
+  tslintEmitErrors?: boolean;
   memoryLimit?: number;
   timings?: boolean;
   diagnosticFormatter?: string;
@@ -22,12 +23,19 @@ class TsCheckerWebpackPlugin {
   private startTime: number = Date.now();
 
   constructor(options: TsCheckerWebpackPluginOptions) {
-    const { tsconfig, tslint, memoryLimit = 512, timings = false, diagnosticFormatter = "ts-loader" } = options;
+    const {
+      tsconfig,
+      tslint,
+      tslintEmitErrors = false,
+      memoryLimit = 512,
+      timings = false,
+      diagnosticFormatter = "ts-loader",
+    } = options;
     this.logger = new Logger();
     if (timings) {
       this.logger.enable();
     }
-    this.checker = new TsCheckerWorker(memoryLimit, timings, tsconfig, diagnosticFormatter, tslint);
+    this.checker = new TsCheckerWorker(memoryLimit, timings, tsconfig, diagnosticFormatter, tslintEmitErrors, tslint);
     this.checker.start();
   }
 

--- a/src/checker/resultSerializer.ts
+++ b/src/checker/resultSerializer.ts
@@ -18,7 +18,8 @@ export type WebpackBuildResult = {
 export const transformToWebpackBuildResult = (
   result: TsCheckerResult,
   contextPath: string,
-  diagnosticFormat: string
+  diagnosticFormat: string,
+  tslintEmitErrors: boolean
 ): WebpackBuildResult => {
   const diagnosticErrors = result.diagnostics.filter(
     (diagnostic: Diagnostic) => DiagnosticCategory[diagnostic.category].toLowerCase() === "error"
@@ -27,8 +28,12 @@ export const transformToWebpackBuildResult = (
     (diagnostic: Diagnostic) => DiagnosticCategory[diagnostic.category].toLowerCase() !== "error"
   );
 
-  const lintErrors = result.lints.filter((failure: RuleFailure) => failure.getRuleSeverity() === "error");
-  const lintWarnings = result.lints.filter((failure: RuleFailure) => failure.getRuleSeverity() !== "error");
+  const lintErrors = result.lints.filter(
+    (failure: RuleFailure) => failure.getRuleSeverity() === "error" || tslintEmitErrors
+  );
+  const lintWarnings = tslintEmitErrors
+    ? []
+    : result.lints.filter((failure: RuleFailure) => failure.getRuleSeverity() !== "error");
 
   const errors = [
     ...diagnosticFormatter(diagnosticErrors, diagnosticFormat, contextPath),

--- a/src/worker/TsCheckerRuntime.ts
+++ b/src/worker/TsCheckerRuntime.ts
@@ -6,6 +6,7 @@ export interface TsCheckerRuntimeConfig {
   tsconfigPath: string;
   diagnosticFormatter: string;
   tslintPath?: string;
+  tslintEmitErrors: boolean;
   timings: boolean;
 }
 
@@ -45,7 +46,7 @@ process.on("message", function(message: any) {
       incrementalChecker.updateBuiltFiles(message.files);
       const result = incrementalChecker.run();
 
-      const webpackResult = transformToWebpackBuildResult(result, contextPath, config.diagnosticFormatter);
+      const webpackResult = transformToWebpackBuildResult(result, contextPath, config.diagnosticFormatter, config.tslintEmitErrors);
       const serialized = serializeWebpackBuildResult(webpackResult);
 
       sendMessage({

--- a/src/worker/TsCheckerWorker.ts
+++ b/src/worker/TsCheckerWorker.ts
@@ -15,13 +15,15 @@ export default class TsCheckerWorker {
     timings: boolean,
     tsconfigPath: string,
     diagnosticFormatter: string,
-    tslintPath?: string
+    tslintEmitErrors: boolean,
+    tslintPath?: string,
   ) {
     this.memoryLimit = memoryLimit;
     this.runtimeConfig = {
       tsconfigPath,
       diagnosticFormatter,
       tslintPath,
+      tslintEmitErrors,
       timings,
     };
     this.exitListener = () => {

--- a/test/__snapshots__/TestCases.test.ts.snap
+++ b/test/__snapshots__/TestCases.test.ts.snap
@@ -133,6 +133,17 @@ Module build failed: error TS5014: Failed to parse file 'xfile': Unexpected toke
 }
 `;
 
+exports[`TestCases tslint-emit-warning-as-error 1`] = `
+Object {
+  "errors": Array [
+    "xfile
+  2:11  warning  ' should be \\"  quotemark
+",
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`TestCases tslint-error 1`] = `
 Object {
   "errors": Array [

--- a/test/testCases/tslint-emit-warning-as-error/src/entry.ts
+++ b/test/testCases/tslint-emit-warning-as-error/src/entry.ts
@@ -1,0 +1,2 @@
+// prettier-ignore
+const x = 'dddd';

--- a/test/testCases/tslint-emit-warning-as-error/tsconfig.json
+++ b/test/testCases/tslint-emit-warning-as-error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/testCases/tslint-emit-warning-as-error/tslint.json
+++ b/test/testCases/tslint-emit-warning-as-error/tslint.json
@@ -1,0 +1,6 @@
+{
+  "defaultSeverity": "warning",
+  "rules": {
+    "quotemark": [true, "double"]
+  }
+}

--- a/test/testCases/tslint-emit-warning-as-error/webpack.config.ts
+++ b/test/testCases/tslint-emit-warning-as-error/webpack.config.ts
@@ -1,0 +1,34 @@
+import * as path from "path";
+import TsCheckerWebpackPlugin from "../../../src/TsCheckerWebpackPlugin";
+
+module.exports = {
+  context: __dirname,
+  entry: "./src/entry.ts",
+  output: {
+    filename: "bundle.js",
+  },
+  resolve: {
+    // Add `.ts` and `.tsx` as a resolvable extension.
+    extensions: [".ts", ".tsx", ".js"], // note if using webpack 1 you'd also need a '' in the array as well
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new TsCheckerWebpackPlugin({
+      tsconfig: path.join(__dirname, "tsconfig.json"),
+      tslint: path.join(__dirname, "tslint.json"),
+      tslintEmitErrors: true,
+    }),
+  ],
+};


### PR DESCRIPTION
Introduces option `tslintEmitErrors` to override the defined severity for each rule and emit failures always as error.

resolves #27 