### PR TITLE
provide more timing information

### DIFF
--- a/src/TsCheckerWebpackPlugin.ts
+++ b/src/TsCheckerWebpackPlugin.ts
@@ -1,5 +1,6 @@
 import { Compiler } from "webpack";
 import TsCheckerWorker from "./worker/TsCheckerWorker";
+import Logger from "./util/Logger";
 import { stripLoader } from "./util/webpackModule";
 import { WebpackBuildResult } from "./checker/resultSerializer";
 
@@ -14,6 +15,7 @@ export interface TsCheckerWebpackPluginOptions {
 class TsCheckerWebpackPlugin {
   private watchMode: boolean = false;
   private compiler: Compiler;
+  private logger: Logger;
   private checker: TsCheckerWorker;
   private current: Promise<WebpackBuildResult | void> | null = null;
   private builtFiles: Array<string> = [];
@@ -21,6 +23,10 @@ class TsCheckerWebpackPlugin {
 
   constructor(options: TsCheckerWebpackPluginOptions) {
     const { tsconfig, tslint, memoryLimit = 512, timings = false, diagnosticFormatter = "ts-loader" } = options;
+    this.logger = new Logger();
+    if (timings) {
+      this.logger.enable();
+    }
     this.checker = new TsCheckerWorker(memoryLimit, timings, tsconfig, diagnosticFormatter, tslint);
     this.checker.start();
   }
@@ -33,6 +39,7 @@ class TsCheckerWebpackPlugin {
     this.compiler.plugin("watch-run", (watching, callback) => {
       this.watchMode = true;
 
+      this.logger.time("ts-checker-webpack-plugin:determine-changed-files");
       const currentTimes = watching.compiler.fileTimestamps;
       // update file cache
       const changed: Array<string> = Object.keys(currentTimes)
@@ -42,6 +49,7 @@ class TsCheckerWebpackPlugin {
           return filePath;
         });
 
+      this.logger.timeEnd("ts-checker-webpack-plugin:determine-changed-files");
       this.current = this.checker.invalidateFiles(changed, []);
       callback();
     });
@@ -53,11 +61,17 @@ class TsCheckerWebpackPlugin {
         callback();
         return;
       }
-
+      this.logger.time("ts-checker-webpack-plugin:wait-for-file-invalidation");
       if (this.current !== null) {
-        this.current.then(() => callback()).catch(callback);
+        this.current
+          .then(() => {
+            this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-file-invalidation");
+            callback();
+          })
+          .catch(callback);
         this.current = null;
       } else {
+        this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-file-invalidation");
         callback();
       }
     });
@@ -68,6 +82,7 @@ class TsCheckerWebpackPlugin {
         return;
       }
 
+      this.logger.time("ts-checker-webpack-plugin:wait-for-built-of-modules");
       let checked = false;
 
       // compilation for modules almost finished, start type checking
@@ -84,6 +99,8 @@ class TsCheckerWebpackPlugin {
         }
 
         // start type checking
+        this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-built-of-modules");
+        this.logger.time("ts-checker-webpack-plugin:type-checking-process");
         this.current = this.checker.check(this.builtFiles);
         checked = true;
       });
@@ -96,9 +113,12 @@ class TsCheckerWebpackPlugin {
         return;
       }
 
+      this.logger.time("ts-checker-webpack-plugin:wait-for-type-checker");
+      this.logger.time("ts-checker-webpack-plugin:wait-for-type-checker:results");
       // block emit until type checking is ready
       (this.current as Promise<WebpackBuildResult>)
         .then((result: any) => {
+          this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-type-checker:results");
           // reset built files
           this.builtFiles.length = 0;
           // pass errors/warnings to webpack
@@ -106,11 +126,17 @@ class TsCheckerWebpackPlugin {
           errors.forEach((error: Error) => compilation.errors.push(error));
           warnings.forEach((error: Error) => compilation.warnings.push(error));
         })
-        .then(() => this.checker.getTypeCheckRelatedFiles())
+        .then(() => {
+          this.logger.time("ts-checker-webpack-plugin:wait-for-type-checker:files");
+          return this.checker.getTypeCheckRelatedFiles();
+        })
         .then(filesToWatch => {
+          this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-type-checker:files");
           // let webpack watch type definition files which are not part of the dependency graph
           // to rebuild on changes automatically
           Array.prototype.push.apply(compilation.fileDependencies, filesToWatch);
+          this.logger.timeEnd("ts-checker-webpack-plugin:wait-for-type-checker");
+          this.logger.timeEnd("ts-checker-webpack-plugin:type-checking-process");
         })
         .then(callback)
         .catch(callback);


### PR DESCRIPTION
Adds more timing logs to track the performance of this plugin.

Especially `ts-checker-webpack-plugin:wait-for-type-checker` is useful to see how long webpack needs to wait for type check.