### PR TITLE
Bring code coverage back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ branches:
     - master
 
 env:
-  - MOCK_PROCESS_FOR_COVERAGE=true
-  - MOCK_PROCESS_FOR_COVERAGE=false
-
-# Test against these versions of OS, Node & Webpack
-matrix:
-  include:
+  # some global options (this duplicated each job in the job)
+  global:
+    - MOCK_PROCESS_FOR_COVERAGE=true
+    - MOCK_PROCESS_FOR_COVERAGE=false
+  # Test against these versions of OS, Node & Webpack
+  matrix:
     # webpack 3 with different typescript versions
     - os: linux
       node_js: 6
@@ -30,6 +30,7 @@ matrix:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=2 TYPESCRIPT_VERSION=2.5
+matrix:
   fast_finish: true
 
 # Test scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ branches:
   only:
     - master
 
+env:
+  - MOCK_PROCESS_FOR_COVERAGE=true
+  - MOCK_PROCESS_FOR_COVERAGE=false
+
 # Test against these versions of OS, Node & Webpack
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,28 @@ branches:
   only:
     - master
 
-env:
-  # some global options (this duplicated each job in the job)
-  global:
-    - MOCK_PROCESS_FOR_COVERAGE=true
-    - MOCK_PROCESS_FOR_COVERAGE=false
-  # Test against these versions of OS, Node & Webpack
-  matrix:
+# Test against these versions of OS, Node & Webpack
+matrix:
+  include:
     # webpack 3 with different typescript versions
     - os: linux
       node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=true
     - os: linux
       node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=false
     - os: linux
       node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=true
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=false
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=true
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=false
     # node 8 with webpack 3 and latest typescript
     - os: linux
       node_js: 8
@@ -30,7 +35,6 @@ env:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=2 TYPESCRIPT_VERSION=2.5
-matrix:
   fast_finish: true
 
 # Test scripts

--- a/src/worker/TsCheckerRuntime.ts
+++ b/src/worker/TsCheckerRuntime.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import IncrementalChecker from "../checker/IncrementalChecker";
 import { transformToWebpackBuildResult, serializeWebpackBuildResult } from "../checker/resultSerializer";
+import { getProcess } from "./process";
 
 export interface TsCheckerRuntimeConfig {
   tsconfigPath: string;
@@ -12,6 +13,7 @@ export interface TsCheckerRuntimeConfig {
   ignoreLints: Array<string>;
 }
 
+const process = getProcess();
 process.on("SIGINT", function() {
   process.exit(130);
 });

--- a/src/worker/TsCheckerWorker.ts
+++ b/src/worker/TsCheckerWorker.ts
@@ -1,8 +1,9 @@
-import { fork, ChildProcess } from "child_process";
+import { ChildProcess } from "child_process";
 import { deserializeWebpackBuildResult, WebpackBuildResult } from "../checker/resultSerializer";
 import pDefer = require("p-defer");
 const supportsColor = require("supports-color");
 import { TsCheckerRuntimeConfig } from "./TsCheckerRuntime";
+import { forkProcess } from "./process";
 
 export default class TsCheckerWorker {
   private process: ChildProcess | null = null;
@@ -46,7 +47,7 @@ export default class TsCheckerWorker {
       process.on("exit", this.exitListener);
 
       // start child process
-      this.process = fork(
+      this.process = forkProcess(
         process.env.TS_CHECKER_ENV === "test"
           ? require.resolve("ts-node/dist/_bin")
           : require.resolve("./TsCheckerRuntime"),

--- a/src/worker/process.ts
+++ b/src/worker/process.ts
@@ -1,7 +1,11 @@
-import { fork, ForkOptions } from "child_process";
+import { fork, ForkOptions, ChildProcess } from "child_process";
 
 export const getProcess = () => process;
 
-export const forkProcess = (modulePath: string, args: string[], options?: ForkOptions) => {
+export const forkProcess: (modulePath: string, args: string[], options?: ForkOptions) => ChildProcess = (
+  modulePath: string,
+  args: string[],
+  options?: ForkOptions
+) => {
   return fork(modulePath, args, options);
 };

--- a/src/worker/process.ts
+++ b/src/worker/process.ts
@@ -1,0 +1,7 @@
+import { fork, ForkOptions } from "child_process";
+
+export const getProcess = () => process;
+
+export const forkProcess = (modulePath: string, args: string[], options?: ForkOptions) => {
+  return fork(modulePath, args, options);
+};

--- a/test/TestCases.test.ts
+++ b/test/TestCases.test.ts
@@ -4,7 +4,7 @@ import webpack = require("webpack");
 import MemoryFs = require("memory-fs");
 import pDefer = require("p-defer");
 import { createAssertExpectation, satisfiesVersionRequirements } from "./_util/testHelper";
-import * as runtimeMock from "./_util/processMock";
+import * as processMock from "./_util/processMock";
 
 const testCasesPath = path.join(__dirname, "testCases");
 const tests = fs.readdirSync(testCasesPath).filter(dir => fs.statSync(path.join(testCasesPath, dir)).isDirectory());
@@ -18,8 +18,8 @@ describe("TestCases", () => {
     return fs.emptyDir(tmpPath);
   });
 
-  beforeEach(() => runtimeMock.register());
-  afterEach(() => runtimeMock.unregister());
+  beforeEach(() => processMock.register());
+  afterEach(() => processMock.unregister());
 
   tests.forEach(testName => {
     const testPath = path.join(testCasesPath, testName);

--- a/test/TestCases.test.ts
+++ b/test/TestCases.test.ts
@@ -4,6 +4,7 @@ import webpack = require("webpack");
 import MemoryFs = require("memory-fs");
 import pDefer = require("p-defer");
 import { createAssertExpectation, satisfiesVersionRequirements } from "./_util/testHelper";
+import * as runtimeMock from "./_util/processMock";
 
 const testCasesPath = path.join(__dirname, "testCases");
 const tests = fs.readdirSync(testCasesPath).filter(dir => fs.statSync(path.join(testCasesPath, dir)).isDirectory());
@@ -16,6 +17,9 @@ describe("TestCases", () => {
   beforeAll(() => {
     return fs.emptyDir(tmpPath);
   });
+
+  beforeEach(() => runtimeMock.register());
+  afterEach(() => runtimeMock.unregister());
 
   tests.forEach(testName => {
     const testPath = path.join(testCasesPath, testName);

--- a/test/WatchCases.test.ts
+++ b/test/WatchCases.test.ts
@@ -4,7 +4,7 @@ import webpack = require("webpack");
 import MemoryFs = require("memory-fs");
 import pDefer = require("p-defer");
 import { createAssertExpectation, satisfiesVersionRequirements } from "./_util/testHelper";
-import * as runtimeMock from "./_util/processMock";
+import * as processMock from "./_util/processMock";
 
 const testCasesPath = path.join(__dirname, "watchCases");
 const tests = fs.readdirSync(testCasesPath).filter(dir => fs.statSync(path.join(testCasesPath, dir)).isDirectory());
@@ -47,8 +47,8 @@ describe("WatchCases", () => {
     return fs.emptyDir(tmpPath);
   });
 
-  beforeEach(() => runtimeMock.register());
-  afterEach(() => runtimeMock.unregister());
+  beforeEach(() => processMock.register());
+  afterEach(() => processMock.unregister());
 
   tests.forEach(testName => {
     const testPath = path.join(testCasesPath, testName);

--- a/test/WatchCases.test.ts
+++ b/test/WatchCases.test.ts
@@ -4,6 +4,7 @@ import webpack = require("webpack");
 import MemoryFs = require("memory-fs");
 import pDefer = require("p-defer");
 import { createAssertExpectation, satisfiesVersionRequirements } from "./_util/testHelper";
+import * as runtimeMock from "./_util/processMock";
 
 const testCasesPath = path.join(__dirname, "watchCases");
 const tests = fs.readdirSync(testCasesPath).filter(dir => fs.statSync(path.join(testCasesPath, dir)).isDirectory());
@@ -45,6 +46,9 @@ describe("WatchCases", () => {
   beforeAll(() => {
     return fs.emptyDir(tmpPath);
   });
+
+  beforeEach(() => runtimeMock.register());
+  afterEach(() => runtimeMock.unregister());
 
   tests.forEach(testName => {
     const testPath = path.join(testCasesPath, testName);

--- a/test/_util/processMock.ts
+++ b/test/_util/processMock.ts
@@ -20,14 +20,12 @@ export const register = () => {
   const eventEmitter = new EventEmitter();
   let env = {};
   const childProcessMock = {
-    on: eventEmitter.on,
-    once: eventEmitter.once,
+    on: eventEmitter.on.bind(eventEmitter),
+    once: eventEmitter.once.bind(eventEmitter),
     send(...args: Array<any>) {
       return eventEmitter.emit("message", ...args);
     },
-    removeAllListeners() {
-      return eventEmitter.removeAllListeners();
-    },
+    removeAllListeners: eventEmitter.removeAllListeners.bind(eventEmitter),
     kill: () => undefined,
     get env() {
       return env;

--- a/test/_util/processMock.ts
+++ b/test/_util/processMock.ts
@@ -1,0 +1,61 @@
+// jest.mock calls are hoisted automatically to the top, so we can do this manually to show this behaviour
+jest.mock("../../src/worker/process");
+
+import { ForkOptions } from "child_process";
+import { EventEmitter } from "events";
+let processUtil = null;
+
+const jest = jest;
+
+export const register = () => {
+  if (process.env.MOCK_PROCESS_FOR_COVERAGE !== "true") {
+    // skip mocking & restore original when mocking is not requested
+    jest.unmock("../../src/worker/process");
+    return;
+  }
+
+  // need to reset modules to reload TsCheckerRuntime & other modules that depend on it to force reload of process
+  jest.resetModules();
+  processUtil = require("../../src/worker/process");
+
+  const eventEmitter = new EventEmitter();
+  let env = {};
+  const childProcessMock = {
+    on(...args) {
+      return eventEmitter.on(...args);
+    },
+    once(...args) {
+      return eventEmitter.once(...args);
+    },
+    send(...args) {
+      return eventEmitter.emit("message", ...args);
+    },
+    removeAllListeners() {
+      return eventEmitter.removeAllListeners();
+    },
+    kill: () => undefined,
+    get env() {
+      return env;
+    },
+  };
+
+  processUtil.getProcess.mockImplementation(() => childProcessMock);
+
+  processUtil.forkProcess.mockImplementation((modulePath: string, args: string[], options: ForkOptions) => {
+    env = options.env;
+    if (args.length > 0) {
+      require(args[0]);
+    } else {
+      require(modulePath);
+    }
+
+    return childProcessMock;
+  });
+};
+
+export const unregister = () => {
+  if (processUtil != null) {
+    processUtil.getProcess.mockRestore();
+    processUtil.forkProcess.mockRestore();
+  }
+};


### PR DESCRIPTION
Avoids spawning a child process so that jest is able to collect code coverage. This special hack introduces some new travis jobs to keep the original ones untouched.

Resolves #17 