### PR TITLE
attempt to show correct coverage on codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=true
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=false
   fast_finish: true
 
 # Test scripts
@@ -22,4 +25,4 @@ script:
 
 # Upload coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -f coverage/*.json
+  - bash <(curl -s https://codecov.io/bash) --env TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
 
 # Upload coverage
 after_success:
-  - if [ "${MOCK_PROCESS_FOR_COVERAGE}" = "true" ]; then bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE; fi
+  - if [ "${MOCK_PROCESS_FOR_COVERAGE}" = "true" ]; then bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json  -e TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,6 @@ matrix:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=true
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=false
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=true
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=false
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=true
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=false
-    # node 8 with webpack 3 and latest typescript
-    - os: linux
-      node_js: 8
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5
-    # webpack 2
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=2 TYPESCRIPT_VERSION=2.5
   fast_finish: true
 
 # Test scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,26 +15,6 @@ matrix:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=false
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=true
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=false
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=true
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=false
-    # node 8 with webpack 3 and latest typescript
-    - os: linux
-      node_js: 8
-      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5
-    # webpack 2
-    - os: linux
-      node_js: 6
-      env: WEBPACK_VERSION=2 TYPESCRIPT_VERSION=2.5
   fast_finish: true
 
 # Test scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,26 @@ matrix:
     - os: linux
       node_js: 6
       env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.3 MOCK_PROCESS_FOR_COVERAGE=false
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=true
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.4 MOCK_PROCESS_FOR_COVERAGE=false
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=true
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5 MOCK_PROCESS_FOR_COVERAGE=false
+    # node 8 with webpack 3 and latest typescript
+    - os: linux
+      node_js: 8
+      env: WEBPACK_VERSION=3 TYPESCRIPT_VERSION=2.5
+    # webpack 2
+    - os: linux
+      node_js: 6
+      env: WEBPACK_VERSION=2 TYPESCRIPT_VERSION=2.5
   fast_finish: true
 
 # Test scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
 
 # Upload coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash) --env TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE
+  - bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
 
 # Upload coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -f coverage/*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
 
 # Upload coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE
+  - if [ "${MOCK_PROCESS_FOR_COVERAGE}" = "true" ]; then bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TRAVIS_NODE_VERSION,WEBPACK_VERSION,TYPESCRIPT_VERSION,MOCK_PROCESS_FOR_COVERAGE; fi


### PR DESCRIPTION
The merging of the coverage reports does not work properly. As a temporary solution we upload only the coverage results from the ones with the mocked process.

Ideally both reports will be respected to get also coverage for process only code.