### PR TITLE
set lib target for tests

### DIFF
--- a/test/testCases/basic-type-error/tsconfig.json
+++ b/test/testCases/basic-type-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/basic-type-no-error/tsconfig.json
+++ b/test/testCases/basic-type-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/code-splitting-import-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/code-splitting-import-no-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/commonjs-usage/tsconfig.json
+++ b/test/testCases/commonjs-usage/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/css-modules-error/tsconfig.json
+++ b/test/testCases/css-modules-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/css-modules-no-error/tsconfig.json
+++ b/test/testCases/css-modules-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/ignore-basic-type-error/tsconfig.json
+++ b/test/testCases/ignore-basic-type-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/testCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/ignore-tslint-rule/tsconfig.json
+++ b/test/testCases/ignore-tslint-rule/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/skip-type-check-on-build-error/tsconfig.json
+++ b/test/testCases/skip-type-check-on-build-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/ts-dependency-only-error/tsconfig.json
+++ b/test/testCases/ts-dependency-only-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/ts-dependency-only-no-error/tsconfig.json
+++ b/test/testCases/ts-dependency-only-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/tsconfig-invalid-option/tsconfig.json
+++ b/test/testCases/tsconfig-invalid-option/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "xxxx": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/tsconfig-syntax-error/tsconfig.json
+++ b/test/testCases/tsconfig-syntax-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/tslint-emit-warning-as-error/tsconfig.json
+++ b/test/testCases/tslint-emit-warning-as-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/tslint-error/tsconfig.json
+++ b/test/testCases/tslint-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/tslint-warning/tsconfig.json
+++ b/test/testCases/tslint-warning/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/use-library-type-definition-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/testCases/use-library-type-definition-no-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "commonjs",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/basic-type-error/tsconfig.json
+++ b/test/watchCases/basic-type-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/basic-type-no-error/tsconfig.json
+++ b/test/watchCases/basic-type-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/check-file-until-error-fixed/tsconfig.json
+++ b/test/watchCases/check-file-until-error-fixed/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/check-interfaces-until-fixed/tsconfig.json
+++ b/test/watchCases/check-interfaces-until-fixed/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/class-hierarchy-types/tsconfig.json
+++ b/test/watchCases/class-hierarchy-types/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/css-modules-error/tsconfig.json
+++ b/test/watchCases/css-modules-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/css-modules-no-error/tsconfig.json
+++ b/test/watchCases/css-modules-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/css-modules-removal-no-error/tsconfig.json
+++ b/test/watchCases/css-modules-removal-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/file-removal-no-error/tsconfig.json
+++ b/test/watchCases/file-removal-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/module-extension-type-definition/tsconfig.json
+++ b/test/watchCases/module-extension-type-definition/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "commonjs",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/node-module-with-type-definition/tsconfig.json
+++ b/test/watchCases/node-module-with-type-definition/tsconfig.json
@@ -5,7 +5,13 @@
     "target": "es5",
     "sourceMap": true,
     "strictNullChecks": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src",

--- a/test/watchCases/react-components/tsconfig.json
+++ b/test/watchCases/react-components/tsconfig.json
@@ -5,7 +5,13 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
-    "jsx": "react"
+    "jsx": "react",
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/ts-dependency-only-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/tslint-error/tsconfig.json
+++ b/test/watchCases/tslint-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/tslint-warning/tsconfig.json
+++ b/test/watchCases/tslint-warning/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"

--- a/test/watchCases/type-patches-error/tsconfig.json
+++ b/test/watchCases/type-patches-error/tsconfig.json
@@ -4,7 +4,13 @@
     "module": "commonjs",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "src"


### PR DESCRIPTION
This makes it possible to fully typecheck, even declaration files in node_modules...
Without this we'll get a Set/Map not defined error.