### PR TITLE
Use skipLibCheck to skip type checking of declaration files

### DIFF
--- a/src/checker/IncrementalChecker.ts
+++ b/src/checker/IncrementalChecker.ts
@@ -40,9 +40,7 @@ export default class IncrementalChecker {
 
     // check only files that were required by webpack
     this.logger.time("ts-checker-webpack-plugin:collect-sourcefiles");
-    const filesToCheck: Array<SourceFile> = this.program
-      .getSourceFiles()
-      .filter((file: SourceFile) => this.fileCache.isFileTypeCheckable(file.fileName)); // this makes it fast
+    const filesToCheck: Array<SourceFile> = this.program.getSourceFiles();
     this.logger.timeEnd("ts-checker-webpack-plugin:collect-sourcefiles");
 
     this.logger.time("ts-checker-webpack-plugin:check-types");

--- a/test/__snapshots__/TestCases.test.ts.snap
+++ b/test/__snapshots__/TestCases.test.ts.snap
@@ -115,6 +115,16 @@ Object {
 }
 `;
 
+exports[`TestCases skipLibCheck-false 1`] = `
+Object {
+  "errors": Array [
+    "xfile
+(1,1): error TS1046",
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`TestCases ts-dependency-only-error 1`] = `
 Object {
   "errors": Array [

--- a/test/__snapshots__/WatchCases.test.ts.snap
+++ b/test/__snapshots__/WatchCases.test.ts.snap
@@ -360,6 +360,33 @@ Object {
 }
 `;
 
+exports[`WatchCases skipLibCheck-false 1`] = `
+Object {
+  "errors": Array [
+    "xfile
+(1,1): error TS1046",
+  ],
+  "warnings": Array [],
+}
+`;
+
+exports[`WatchCases skipLibCheck-false 2`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`WatchCases skipLibCheck-false 3`] = `
+Object {
+  "errors": Array [
+    "xfile
+(1,17): error TS2345",
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`WatchCases ts-dependency-only-error 1`] = `
 Object {
   "errors": Array [],

--- a/test/__snapshots__/WatchCases.test.ts.snap
+++ b/test/__snapshots__/WatchCases.test.ts.snap
@@ -387,6 +387,18 @@ Object {
 }
 `;
 
+exports[`WatchCases skipLibCheck-false 4`] = `
+Object {
+  "errors": Array [
+    "xfile
+(1,17): error TS2345",
+    "xfile
+(1,1): error TS1046",
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`WatchCases ts-dependency-only-error 1`] = `
 Object {
   "errors": Array [],

--- a/test/testCases/basic-type-error/tsconfig.json
+++ b/test/testCases/basic-type-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/basic-type-no-error/tsconfig.json
+++ b/test/testCases/basic-type-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es6",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-no-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es6",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
+++ b/test/testCases/code-splitting-import-ts-dependency-no-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "esnext",
     "target": "es6",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/commonjs-usage/tsconfig.json
+++ b/test/testCases/commonjs-usage/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/css-modules-error/tsconfig.json
+++ b/test/testCases/css-modules-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/css-modules-no-error/tsconfig.json
+++ b/test/testCases/css-modules-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/ignore-basic-type-error/tsconfig.json
+++ b/test/testCases/ignore-basic-type-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/testCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/testCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/ignore-tslint-rule/tsconfig.json
+++ b/test/testCases/ignore-tslint-rule/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/skip-type-check-on-build-error/tsconfig.json
+++ b/test/testCases/skip-type-check-on-build-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/skipLibCheck-false/src/global.d.ts
+++ b/test/testCases/skipLibCheck-false/src/global.d.ts
@@ -1,0 +1,1 @@
+function awesomeIncluded(x: string): string;

--- a/test/testCases/skipLibCheck-false/tsconfig.json
+++ b/test/testCases/skipLibCheck-false/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "skipLibCheck": false,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/testCases/skipLibCheck-false/webpack.config.ts
+++ b/test/testCases/skipLibCheck-false/webpack.config.ts
@@ -1,0 +1,32 @@
+import * as path from "path";
+import TsCheckerWebpackPlugin from "../../../src/TsCheckerWebpackPlugin";
+
+module.exports = {
+  context: __dirname,
+  entry: "./src/entry.ts",
+  output: {
+    filename: "bundle.js",
+  },
+  resolve: {
+    // Add `.ts` and `.tsx` as a resolvable extension.
+    extensions: [".ts", ".tsx", ".js"], // note if using webpack 1 you'd also need a '' in the array as well
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new TsCheckerWebpackPlugin({
+      tsconfig: path.join(__dirname, "tsconfig.json"),
+    }),
+  ],
+};

--- a/test/testCases/ts-dependency-only-error/tsconfig.json
+++ b/test/testCases/ts-dependency-only-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/ts-dependency-only-no-error/tsconfig.json
+++ b/test/testCases/ts-dependency-only-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/tsconfig-invalid-option/tsconfig.json
+++ b/test/testCases/tsconfig-invalid-option/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "xxxx": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/tsconfig-syntax-error/tsconfig.json
+++ b/test/testCases/tsconfig-syntax-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/tslint-emit-warning-as-error/tsconfig.json
+++ b/test/testCases/tslint-emit-warning-as-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/tslint-error/tsconfig.json
+++ b/test/testCases/tslint-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/tslint-warning/tsconfig.json
+++ b/test/testCases/tslint-warning/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/use-library-type-definition-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es6",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/use-library-type-definition-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es6",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/use-library-type-definition-no-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-no-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/testCases/use-library-type-definition-no-error/tsconfig.json
+++ b/test/testCases/use-library-type-definition-no-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "target": "es2015",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/basic-type-error/tsconfig.json
+++ b/test/watchCases/basic-type-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/basic-type-no-error/tsconfig.json
+++ b/test/watchCases/basic-type-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/check-file-until-error-fixed/tsconfig.json
+++ b/test/watchCases/check-file-until-error-fixed/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/check-interfaces-until-fixed/tsconfig.json
+++ b/test/watchCases/check-interfaces-until-fixed/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/class-hierarchy-types/tsconfig.json
+++ b/test/watchCases/class-hierarchy-types/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/css-modules-error/tsconfig.json
+++ b/test/watchCases/css-modules-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/css-modules-no-error/tsconfig.json
+++ b/test/watchCases/css-modules-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/css-modules-removal-no-error/tsconfig.json
+++ b/test/watchCases/css-modules-removal-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/file-removal-no-error/tsconfig.json
+++ b/test/watchCases/file-removal-no-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
+++ b/test/watchCases/ignore-child-compiler-no-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/module-extension-type-definition/tsconfig.json
+++ b/test/watchCases/module-extension-type-definition/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/module-extension-type-definition/tsconfig.json
+++ b/test/watchCases/module-extension-type-definition/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/node-module-with-type-definition/tsconfig.json
+++ b/test/watchCases/node-module-with-type-definition/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "es5",
     "sourceMap": true,
     "strictNullChecks": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/node-module-with-type-definition/tsconfig.json
+++ b/test/watchCases/node-module-with-type-definition/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "strictNullChecks": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/react-components/tsconfig.json
+++ b/test/watchCases/react-components/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "jsx": "react",
     "lib": [
       "es2015",

--- a/test/watchCases/skipLibCheck-false/steps/0/entry.ts
+++ b/test/watchCases/skipLibCheck-false/steps/0/entry.ts
@@ -1,0 +1,1 @@
+awesomeIncluded("");

--- a/test/watchCases/skipLibCheck-false/steps/0/global.d.ts
+++ b/test/watchCases/skipLibCheck-false/steps/0/global.d.ts
@@ -1,0 +1,1 @@
+function awesomeIncluded(x: string): string;

--- a/test/watchCases/skipLibCheck-false/steps/1/global.d.ts
+++ b/test/watchCases/skipLibCheck-false/steps/1/global.d.ts
@@ -1,0 +1,1 @@
+declare function awesomeIncluded(x: string): string;

--- a/test/watchCases/skipLibCheck-false/steps/2/entry.ts
+++ b/test/watchCases/skipLibCheck-false/steps/2/entry.ts
@@ -1,0 +1,1 @@
+awesomeIncluded(5);

--- a/test/watchCases/skipLibCheck-false/steps/3/global.d.ts
+++ b/test/watchCases/skipLibCheck-false/steps/3/global.d.ts
@@ -1,0 +1,1 @@
+function awesomeIncluded(x: string): string;

--- a/test/watchCases/skipLibCheck-false/tsconfig.json
+++ b/test/watchCases/skipLibCheck-false/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "skipLibCheck": false,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/watchCases/skipLibCheck-false/webpack.config.ts
+++ b/test/watchCases/skipLibCheck-false/webpack.config.ts
@@ -1,0 +1,32 @@
+import * as path from "path";
+import TsCheckerWebpackPlugin from "../../../src/TsCheckerWebpackPlugin";
+
+module.exports = {
+  context: __dirname,
+  entry: "./src/entry.ts",
+  output: {
+    filename: "bundle.js",
+  },
+  resolve: {
+    // Add `.ts` and `.tsx` as a resolvable extension.
+    extensions: [".ts", ".tsx", ".js"], // note if using webpack 1 you'd also need a '' in the array as well
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new TsCheckerWebpackPlugin({
+      tsconfig: path.join(__dirname, "tsconfig.json"),
+    }),
+  ],
+};

--- a/test/watchCases/ts-dependency-only-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-2-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true,
+    "noImplicitAny": true, "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
+++ b/test/watchCases/ts-dependency-only-removal-error/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es6",
     "target": "es5",
     "sourceMap": true,
-    "noImplicitAny": true, "skipLibCheck": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/tslint-error/tsconfig.json
+++ b/test/watchCases/tslint-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/tslint-warning/tsconfig.json
+++ b/test/watchCases/tslint-warning/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",

--- a/test/watchCases/type-patches-error/tsconfig.json
+++ b/test/watchCases/type-patches-error/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "lib": [
       "es2015",
       "es2016",


### PR DESCRIPTION
TypeScript offers already a away to skip type checking of declaration files. I made some tests and the performance with `skipLibCheck = true` is the same as before.

This makes our own filtering of those files obsolete and gives the control back to user.