### PR TITLE
traverse dependents only for modified files

### DIFF
--- a/src/util/FileCache.ts
+++ b/src/util/FileCache.ts
@@ -59,7 +59,10 @@ export default class FileCache {
   }
 
   add(file: string, source: SourceFile) {
-    this.added.set(file, file);
+    if (this.getSource(file) == null) {
+      this.added.set(file, file);
+    }
+
     this.update(file, {
       source,
       dependencies: [], // dependencies will be set later, see updateDependencies


### PR DESCRIPTION
We don't need to traverse dependents of untouched files that failed before. This can reduce the files to check drastically if you fix several type errors...