### PR TITLE
pass env variables from parent to child process

### DIFF
--- a/src/worker/TsCheckerWorker.ts
+++ b/src/worker/TsCheckerWorker.ts
@@ -56,6 +56,7 @@ export default class TsCheckerWorker {
           cwd: process.cwd(),
           execArgv: [`--max-old-space-size=${this.memoryLimit}`],
           env: {
+            ...process.env,
             FORCE_COLOR: Number(supportsColor),
             TS_CHECKER_CONFIG: JSON.stringify(this.runtimeConfig),
           },


### PR DESCRIPTION
variables like NODE_PATH should be passed to child process